### PR TITLE
Add /episodes route with tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5416,6 +5416,11 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
       "integrity": "sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ=="
     },
+    "ramda": {
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
+    },
     "range-parser": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "cors": "^2.8.5",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
-    "mongoose": "^5.10.11"
+    "mongoose": "^5.10.11",
+    "ramda": "^0.27.1"
   },
   "devDependencies": {
     "eslint": "^7.12.1",

--- a/src/__tests__/v1.test.js
+++ b/src/__tests__/v1.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable no-undef */
-const createServer = require('../createServer');
 const request = require('supertest');
+
+const createServer = require('../createServer');
 
 const app = createServer();
 

--- a/src/__tests__/v1.test.js
+++ b/src/__tests__/v1.test.js
@@ -4,14 +4,15 @@ const request = require('supertest');
 const createServer = require('../createServer');
 
 const app = createServer();
+const route = '/v1/';
 
-test('GET on "/v1/" returns status 200', async () => {
-  const res = await request(app).get('/v1/');
+test(`GET on ${route} returns status 200`, async () => {
+  const res = await request(app).get(route);
   expect(res.status).toBe(200);
 });
 
-test('GET on "/v1/" returns JSON with UTF-8', async () => {
-  const res = await request(app).get('/v1/');
+test(`GET on ${route} returns JSON with UTF-8`, async () => {
+  const res = await request(app).get(route);
   expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
 });
 

--- a/src/__tests__/v1episodes.test.js
+++ b/src/__tests__/v1episodes.test.js
@@ -18,28 +18,28 @@ afterAll(async () => {
   await mongoose.connection.close();
 });
 
-test('GET on "/v1/episodes" returns status 200', async () => {
+test(`GET on '${route}' returns status 200`, async () => {
   const res = await request(app).get(route);
   expect(res.status).toBe(200);
 });
 
-test('GET on "/v1/episodes" returns JSON with UTF-8', async () => {
-  const res = await request(app).get('/v1/episodes');
+test(`GET on '${route}' returns JSON with UTF-8`, async () => {
+  const res = await request(app).get(route);
   expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
 });
 
-test('GET on "/v1/episodes" returns Array', async () => {
-  const res = await request(app).get('/v1/episodes');
+test(`GET on '${route}' returns Array`, async () => {
+  const res = await request(app).get(route);
   expect(R.is(Array, res.body)).toBeTruthy();
 });
 
-test('GET on "/v1/episodes" returns Array of Objects', async () => {
-  const res = await request(app).get('/v1/episodes');
+test(`GET on '${route}' returns Array of Objects`, async () => {
+  const res = await request(app).get(route);
   expect(R.is(Object, res.body[0])).toBeTruthy();
 });
 
-test('GET on "/v1/episodes" returns Objects with correct properties', async () => {
-  const res = await request(app).get('/v1/episodes');
+test(`GET on '${route}' returns Objects with correct properties`, async () => {
+  const res = await request(app).get(route);
   expect(res.body[0]).toMatchObject({
     episode: expect.any(String),
     name: expect.any(String),
@@ -50,13 +50,13 @@ test('GET on "/v1/episodes" returns Objects with correct properties', async () =
   });
 });
 
-test('GET on "/v1/episodes" returns Objects without _id property', async () => {
-  const res = await request(app).get('/v1/episodes');
+test(`GET on '${route}' returns Objects without _id property`, async () => {
+  const res = await request(app).get(route);
   expect(res.body[0]._id).toBeUndefined();
 });
 
-test('GET on "/v1/episodes" starts with Episode 1 of Season 1', async () => {
-  const res = await request(app).get('/v1/episodes');
+test(`GET on '${route}' starts with Episode 1 of Season 1`, async () => {
+  const res = await request(app).get(route);
   expect(res.body[0]).toMatchObject({
     episode: 'Episode 1',
     season: '1',

--- a/src/__tests__/v1episodes.test.js
+++ b/src/__tests__/v1episodes.test.js
@@ -1,0 +1,64 @@
+/* eslint-disable no-undef */
+require('dotenv').config();
+const request = require('supertest');
+const mongoose = require('mongoose');
+const R = require('ramda');
+
+const createServer = require('../createServer');
+const connectDB = require('../dbInit');
+
+const app = createServer();
+const route = '/v1/episodes';
+
+beforeAll(async () => {
+  await connectDB();
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+});
+
+test('GET on "/v1/episodes" returns status 200', async () => {
+  const res = await request(app).get(route);
+  expect(res.status).toBe(200);
+});
+
+test('GET on "/v1/episodes" returns JSON with UTF-8', async () => {
+  const res = await request(app).get('/v1/episodes');
+  expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+});
+
+test('GET on "/v1/episodes" returns Array', async () => {
+  const res = await request(app).get('/v1/episodes');
+  expect(R.is(Array, res.body)).toBeTruthy();
+});
+
+test('GET on "/v1/episodes" returns Array of Objects', async () => {
+  const res = await request(app).get('/v1/episodes');
+  expect(R.is(Object, res.body[0])).toBeTruthy();
+});
+
+test('GET on "/v1/episodes" returns Objects with correct properties', async () => {
+  const res = await request(app).get('/v1/episodes');
+  expect(res.body[0]).toMatchObject({
+    episode: expect.any(String),
+    name: expect.any(String),
+    synopsis: expect.any(String),
+    airdate: expect.any(String),
+    season: expect.any(String),
+    characters: expect.any(Array),
+  });
+});
+
+test('GET on "/v1/episodes" returns Objects without _id property', async () => {
+  const res = await request(app).get('/v1/episodes');
+  expect(res.body[0]._id).toBeUndefined();
+});
+
+test('GET on "/v1/episodes" starts with Episode 1 of Season 1', async () => {
+  const res = await request(app).get('/v1/episodes');
+  expect(res.body[0]).toMatchObject({
+    episode: 'Episode 1',
+    season: '1',
+  });
+});

--- a/src/api/v1.js
+++ b/src/api/v1.js
@@ -2,7 +2,9 @@ const express = require('express');
 const api = express.Router();
 
 const helloWorld = require('../controllers/v1/helloWorld');
+const getAllEpisodes = require('../controllers/v1/getAllEpisodes');
 
 api.route('/').get(helloWorld);
+api.route('/episodes').get(getAllEpisodes);
 
 module.exports = api;

--- a/src/controllers/v1/getAllEpisodes.js
+++ b/src/controllers/v1/getAllEpisodes.js
@@ -1,0 +1,34 @@
+/* eslint-disable indent */
+const Episode = require('../../models/Episode');
+
+const getAllEpisodes = async (req, res) => {
+  const episodes = await Episode.find({}, { _id: 0 });
+
+  const seasonOne = [
+    ...episodes
+      .filter((ep) => ep.season === '1')
+      .sort((a, b) =>
+        a.episode[a.episode.length - 1] > b.episode[b.episode.length - 1]
+          ? 1
+          : b.episode[b.episode.length - 1] > a.episode[a.episode.length - 1]
+          ? -1
+          : 0
+      ),
+  ];
+
+  const seasonTwo = [
+    ...episodes
+      .filter((ep) => ep.season === '2')
+      .sort((a, b) =>
+        a.episode[a.episode.length - 1] > b.episode[b.episode.length - 1]
+          ? 1
+          : b.episode[b.episode.length - 1] > a.episode[a.episode.length - 1]
+          ? -1
+          : 0
+      ),
+  ];
+
+  res.status(200).json([...seasonOne, ...seasonTwo]);
+};
+
+module.exports = getAllEpisodes;

--- a/src/models/Episode.js
+++ b/src/models/Episode.js
@@ -6,6 +6,7 @@ const EpisodeSchema = new Schema({
   name: String,
   synopsis: String,
   airdate: Date,
+  season: String,
   characters: [String],
 });
 


### PR DESCRIPTION
This will add the `/episodes`-route returning all the episodes in the right order. It also adds the `season`-field to the `Episode`-model.