### PR TITLE
Add route to query episodes by id & id-field for Episode model

### DIFF
--- a/src/__tests__/v1episodeById.test.js
+++ b/src/__tests__/v1episodeById.test.js
@@ -1,0 +1,88 @@
+/* eslint-disable no-undef */
+require('dotenv').config();
+const request = require('supertest');
+const mongoose = require('mongoose');
+const R = require('ramda');
+
+const createServer = require('../createServer');
+const connectDB = require('../dbInit');
+
+const app = createServer();
+const route = (id) => `/v1/episodes/${id || 1}`;
+
+beforeAll(async () => {
+  await connectDB();
+});
+
+afterAll(async () => {
+  await mongoose.connection.close();
+});
+
+describe('Get episode by id', () => {
+  test(`GET on '${route()}' returns status 200`, async () => {
+    const res = await request(app).get(route());
+    expect(res.status).toBe(200);
+  });
+
+  test(`GET on '${route()}' returns JSON with UTF-8`, async () => {
+    const res = await request(app).get(route());
+    expect(res.headers['content-type']).toBe('application/json; charset=utf-8');
+  });
+
+  test(`GET on '${route()}' returns Object`, async () => {
+    const res = await request(app).get(route());
+    expect(R.is(Object, res.body)).toBeTruthy();
+  });
+
+  test(`GET on '${route()}' returns Objects with correct properties`, async () => {
+    const res = await request(app).get(route());
+    expect(res.body).toMatchObject({
+      id: expect.any(Number),
+      episode: expect.any(String),
+      name: expect.any(String),
+      synopsis: expect.any(String),
+      airdate: expect.any(String),
+      season: expect.any(String),
+      characters: expect.any(Array),
+    });
+  });
+
+  test(`GET on '${route()}' returns Objects without _id property`, async () => {
+    const res = await request(app).get(route());
+    expect(res.body._id).toBeUndefined();
+  });
+
+  test(`GET on '${route()}' returns Object with id 1`, async () => {
+    const res = await request(app).get(route());
+    expect(res.body).toMatchObject({
+      id: 1,
+    });
+  });
+
+  test(`GET on '${route(17)}' returns status 404`, async () => {
+    const res = await request(app).get(route(17));
+    expect(res.status).toBe(404);
+  });
+
+  test(`GET on '${route(17)}' returns JSON with Error properties`, async () => {
+    const res = await request(app).get(route(17));
+    expect(res.body).toMatchObject({
+      error: true,
+      code: 404,
+    });
+  });
+
+  test(`GET on '${route('abc')}' returns status 400`, async () => {
+    const res = await request(app).get(route('abc'));
+    expect(res.status).toBe(400);
+  });
+
+  // prettier-ignore
+  test(`GET on '${route('abc')}' returns JSON with Error properties`, async () => {
+    const res = await request(app).get(route('abc'));
+    expect(res.body).toMatchObject({
+      error: true,
+      code: 400,
+    });
+  });
+});

--- a/src/__tests__/v1episodes.test.js
+++ b/src/__tests__/v1episodes.test.js
@@ -42,6 +42,7 @@ describe('Get all episodes', () => {
   test(`GET on '${route}' returns Objects with correct properties`, async () => {
     const res = await request(app).get(route);
     expect(res.body[0]).toMatchObject({
+      id: expect.any(Number),
       episode: expect.any(String),
       name: expect.any(String),
       synopsis: expect.any(String),

--- a/src/__tests__/v1episodes.test.js
+++ b/src/__tests__/v1episodes.test.js
@@ -57,10 +57,22 @@ describe('Get all episodes', () => {
     expect(res.body[0]._id).toBeUndefined();
   });
 
-  test(`GET on '${route}' starts with Episode 1 of Season 1`, async () => {
+  test(`GET on '${route}' starts with id 1`, async () => {
     const res = await request(app).get(route);
     expect(res.body[0]).toMatchObject({
       id: 1,
     });
+  });
+
+  test(`GET on '${route}' ends with id 16`, async () => {
+    const res = await request(app).get(route);
+    expect(res.body[res.body.length - 1]).toMatchObject({
+      id: 16,
+    });
+  });
+
+  test(`GET on '${route}' returns exactly 16 episodes`, async () => {
+    const res = await request(app).get(route);
+    expect(res.body.length).toBe(16);
   });
 });

--- a/src/__tests__/v1episodes.test.js
+++ b/src/__tests__/v1episodes.test.js
@@ -60,8 +60,7 @@ describe('Get all episodes', () => {
   test(`GET on '${route}' starts with Episode 1 of Season 1`, async () => {
     const res = await request(app).get(route);
     expect(res.body[0]).toMatchObject({
-      episode: 'Episode 1',
-      season: '1',
+      id: 1,
     });
   });
 });

--- a/src/api/v1.js
+++ b/src/api/v1.js
@@ -3,10 +3,12 @@ const api = express.Router();
 
 const helloWorld = require('../controllers/v1/helloWorld');
 const getAllEpisodes = require('../controllers/v1/getAllEpisodes');
+const getEpisodeById = require('../controllers/v1/getEpisodeById');
 const getAllCharacters = require('../controllers/v1/getAllCharacters');
 
 api.route('/').get(helloWorld);
 api.route('/episodes').get(getAllEpisodes);
+api.route('/episodes/:eid').get(getEpisodeById);
 api.route('/characters').get(getAllCharacters);
 
 module.exports = api;

--- a/src/controllers/v1/getAllCharacters.js
+++ b/src/controllers/v1/getAllCharacters.js
@@ -1,9 +1,13 @@
 const Character = require('../../models/Character');
 
-const getAllCharacters = async (req, res) => {
-  const characters = await Character.find({}, { _id: 0 });
+const getAllCharacters = async (req, res, next) => {
+  try {
+    const characters = await Character.find({}, { _id: 0 });
 
-  res.status(200).json(characters);
+    res.status(200).json(characters);
+  } catch (e) {
+    next(e);
+  }
 };
 
 module.exports = getAllCharacters;

--- a/src/controllers/v1/getAllCharacters.js
+++ b/src/controllers/v1/getAllCharacters.js
@@ -1,4 +1,3 @@
-/* eslint-disable indent */
 const Character = require('../../models/Character');
 
 const getAllCharacters = async (req, res) => {

--- a/src/controllers/v1/getAllEpisodes.js
+++ b/src/controllers/v1/getAllEpisodes.js
@@ -3,32 +3,9 @@ const Episode = require('../../models/Episode');
 
 const getAllEpisodes = async (req, res) => {
   const episodes = await Episode.find({}, { _id: 0 });
+  const sortedEpisodes = [...episodes.sort((a, b) => a.id - b.id)];
 
-  const seasonOne = [
-    ...episodes
-      .filter((ep) => ep.season === '1')
-      .sort((a, b) =>
-        a.episode[a.episode.length - 1] > b.episode[b.episode.length - 1]
-          ? 1
-          : b.episode[b.episode.length - 1] > a.episode[a.episode.length - 1]
-          ? -1
-          : 0
-      ),
-  ];
-
-  const seasonTwo = [
-    ...episodes
-      .filter((ep) => ep.season === '2')
-      .sort((a, b) =>
-        a.episode[a.episode.length - 1] > b.episode[b.episode.length - 1]
-          ? 1
-          : b.episode[b.episode.length - 1] > a.episode[a.episode.length - 1]
-          ? -1
-          : 0
-      ),
-  ];
-
-  res.status(200).json([...seasonOne, ...seasonTwo]);
+  res.status(200).json(sortedEpisodes);
 };
 
 module.exports = getAllEpisodes;

--- a/src/controllers/v1/getAllEpisodes.js
+++ b/src/controllers/v1/getAllEpisodes.js
@@ -1,4 +1,3 @@
-/* eslint-disable indent */
 const Episode = require('../../models/Episode');
 
 const getAllEpisodes = async (req, res) => {

--- a/src/controllers/v1/getAllEpisodes.js
+++ b/src/controllers/v1/getAllEpisodes.js
@@ -1,10 +1,14 @@
 const Episode = require('../../models/Episode');
 
-const getAllEpisodes = async (req, res) => {
-  const episodes = await Episode.find({}, { _id: 0 });
-  const sortedEpisodes = [...episodes.sort((a, b) => a.id - b.id)];
+const getAllEpisodes = async (req, res, next) => {
+  try {
+    const episodes = await Episode.find({}, { _id: 0 });
+    const sortedEpisodes = [...episodes.sort((a, b) => a.id - b.id)];
 
-  res.status(200).json(sortedEpisodes);
+    res.status(200).json(sortedEpisodes);
+  } catch (e) {
+    next(e);
+  }
 };
 
 module.exports = getAllEpisodes;

--- a/src/controllers/v1/getEpisodeById.js
+++ b/src/controllers/v1/getEpisodeById.js
@@ -1,0 +1,24 @@
+const Episode = require('../../models/Episode');
+
+const getEpisodeById = async (req, res, next) => {
+  try {
+    const { eid } = req.params;
+
+    if (isNaN(+eid)) {
+      return res
+        .status(400)
+        .json({ error: true, code: 400, message: '400 - Bad Request' });
+    }
+
+    const episode = await Episode.findOne({ id: +eid }, { _id: 0 });
+
+    if (episode) return res.status(200).json(episode);
+    return res
+      .status(404)
+      .json({ error: true, code: 404, message: '404 - Not found' });
+  } catch (e) {
+    next(e);
+  }
+};
+
+module.exports = getEpisodeById;

--- a/src/middleware/errorHandler.js
+++ b/src/middleware/errorHandler.js
@@ -1,6 +1,8 @@
 const errorHandler = (err, req, res, next) => {
   console.error(err.stack);
-  res.status(500).send('Something broke!');
+  res
+    .status(500)
+    .json({ error: true, code: 500, message: '500 - Server Error' });
 };
 
 module.exports = errorHandler;

--- a/src/models/Episode.js
+++ b/src/models/Episode.js
@@ -2,6 +2,7 @@ const mongoose = require('mongoose');
 const Schema = mongoose.Schema;
 
 const EpisodeSchema = new Schema({
+  id: Number,
   episode: String,
   name: String,
   synopsis: String,


### PR DESCRIPTION
This adds the `/v1/episodes/:eid`-route, including controller, tests & `id`-field for the Episode model. The test DB has been updated to match the model. I have also updated the `getAllEpisodes` controller & tests to use the `id`-property for sorting.